### PR TITLE
Set proper Content-type header on SAML AttributeQuery

### DIFF
--- a/aa-server/src/main/java/aa/aggregators/sab/SabAttributeAggregator.java
+++ b/aa-server/src/main/java/aa/aggregators/sab/SabAttributeAggregator.java
@@ -10,7 +10,9 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import javax.xml.stream.XMLStreamException;
@@ -29,6 +31,7 @@ public class SabAttributeAggregator extends AbstractAttributeAggregator {
 
     private static final DateTimeFormatter dateTimeFormatter = ISODateTimeFormat.dateTimeNoMillis().withZone(DateTimeZone.UTC);
     private final String template;
+    private HttpHeaders httpHeaders = new HttpHeaders();
 
     private final SabResponseParser parser = new SabResponseParser();
 
@@ -45,7 +48,8 @@ public class SabAttributeAggregator extends AbstractAttributeAggregator {
     public List<UserAttribute> aggregate(List<UserAttribute> input, Map<String, List<ArpValue>> arpAttributes) {
         String userId = getUserAttributeSingleValue(input, NAME_ID);
         String request = request(userId);
-        ResponseEntity<String> response = getRestTemplate().exchange(endpoint(), HttpMethod.POST, new HttpEntity<>(request), String.class);
+        this.httpHeaders.setContentType(new MediaType("application", "soap+xml"));
+        ResponseEntity<String> response = getRestTemplate().exchange(endpoint(), HttpMethod.POST, new HttpEntity<>(request, this.httpHeaders), String.class);
         Map<SabInfoType, List<String>> result;
         String body = null;
         try {

--- a/aa-server/src/main/java/aa/aggregators/sab/SabAttributeAggregator.java
+++ b/aa-server/src/main/java/aa/aggregators/sab/SabAttributeAggregator.java
@@ -49,6 +49,7 @@ public class SabAttributeAggregator extends AbstractAttributeAggregator {
         String userId = getUserAttributeSingleValue(input, NAME_ID);
         String request = request(userId);
         this.httpHeaders.setContentType(new MediaType("text", "xml"));
+        this.httpHeaders.set("SOAPAction", "http://www.oasis-open.org/committees/security");
         ResponseEntity<String> response = getRestTemplate().exchange(endpoint(), HttpMethod.POST, new HttpEntity<>(request, this.httpHeaders), String.class);
         Map<SabInfoType, List<String>> result;
         String body = null;

--- a/aa-server/src/main/java/aa/aggregators/sab/SabAttributeAggregator.java
+++ b/aa-server/src/main/java/aa/aggregators/sab/SabAttributeAggregator.java
@@ -48,7 +48,7 @@ public class SabAttributeAggregator extends AbstractAttributeAggregator {
     public List<UserAttribute> aggregate(List<UserAttribute> input, Map<String, List<ArpValue>> arpAttributes) {
         String userId = getUserAttributeSingleValue(input, NAME_ID);
         String request = request(userId);
-        this.httpHeaders.setContentType(new MediaType("application", "soap+xml"));
+        this.httpHeaders.setContentType(new MediaType("text", "xml"));
         ResponseEntity<String> response = getRestTemplate().exchange(endpoint(), HttpMethod.POST, new HttpEntity<>(request, this.httpHeaders), String.class);
         Map<SabInfoType, List<String>> result;
         String body = null;


### PR DESCRIPTION
@thijskh I tried playing with this aggregator in conjunction with SSP's [simplesamlphp-module-exampleattributeserver](https://github.com/simplesamlphp/simplesamlphp-module-exampleattributeserver) and then hit the [UnsupportedBindingException](https://github.com/simplesamlphp/saml2/blob/v4.6.3/src/SAML2/Binding.php#L90) on line 109

I was wondering, since you are using SSP for SAB as well, why this never affected you. This appears to be an appropriate fix.