### PR TITLE
Add reusable REST Attribute Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,73 @@ New Attribute Authorities first must be added and configured in `attributeAuthor
 
 To actually use the new authority in the test/acc/prod environment it also needs to be configured in OpenConext-deploy [attributeAuthorities.yml.j2](https://github.com/OpenConext/OpenConext-deploy/blob/master/roles/attribute-aggregation-server/templates/attributeAuthorities.yml.j2).
 
+#### REST attribute aggregator
+This reusable aggregator can be used for retrieving data from a REST endpoint and supports various options for configuring a HTTP request to that endpoint e.g. an API key.
+Using this type does not require adding an authority implementation.
+
+New entries are added in attributeAuthorities.yml.
+
+Below is an example of the full configuration with explanations for the options:
+
+    - {
+        id: "<id>",
+        description: "<description>",
+        endpoint: "<endpoint>",
+        type: "rest",
+        // Username for basic authentication
+        user: "",
+        // Password for basic authentication
+        password: "",
+        // Headers to add in the HTTP request
+        headers: [
+            {
+              "key": "<key>",
+              "value": "<value>",
+            }
+        ],
+        // Path parameters to use in the value for 'endpoint'
+        // Wildcards can be added with %s e.g. https://endpoint/%s/subpath/%s...
+        // The index below will correspond to the order in which the wildcards are replaced
+        // sourceAttribute refers to the attribute received from EngineBlock to use as the substitute
+        pathParams: [
+        {
+            "index": 0,
+            "sourceAttribute": "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+        },
+        {
+            "index": 1,
+            "sourceAttribute": "urn:mace:dir:attribute-def:uid"
+        }
+        ],
+        // Options are 'GET', 'POST', 'PUT', 'DELETE', default is 'GET'
+        requestMethod: 'GET',
+        // Request parameters to use in the HTTP request, will be appended as ?name=value&...
+        // sourceAttribute refers to the attribute received from EngineBlock to use as the substitute
+        requestParams: [
+            {
+                "name": "<name>",
+                "sourceAttribute": "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+            }
+        ],
+        // Mapping to apply to the response received from the HTTP request
+        // responseKey corresponds to the field in the response object of which to retrieve the value
+        // targetAttribute corresponds to the attribute to send the value as in the result of aggregation
+        mappings: [
+        {
+            "responseKey": "myResponseKey",
+            "targetAttribute": "myTargetAttribute"
+        }
+        ],
+        timeOut: 15000,
+        attributes: [],
+        requiredInputAttributes: [
+            {
+                name: "urn:mace:terena.org:attribute-def:schacHomeOrganization",
+            }
+        ],
+        validationRegExp: "[a-zA-Z0-9]*"
+    }
+
 ### [Configuration and deployment](#configuration-and-deployment)
 
 On its classpath, the application has an [application.yml](aa-server/src/main/resources/application.yml) file that

--- a/aa-server/src/main/java/aa/aggregators/AttributeAggregatorConfiguration.java
+++ b/aa-server/src/main/java/aa/aggregators/AttributeAggregatorConfiguration.java
@@ -4,11 +4,10 @@ import aa.aggregators.ala.AlaAttributeAggregator;
 import aa.aggregators.eduid.EduIdAttributeAggregator;
 import aa.aggregators.entitlements.EntitlementsAggregator;
 import aa.aggregators.idin.IdinAttributeAggregator;
-import aa.aggregators.manage.ManageAttributeAggregator;
-import aa.aggregators.manage.ManageConfig;
 import aa.aggregators.manage.SurfCrmAttributeAggregator;
 import aa.aggregators.orcid.OrcidAttributeAggregator;
 import aa.aggregators.pseudo.PseudoEmailAggregator;
+import aa.aggregators.rest.RestAttributeAggregator;
 import aa.aggregators.sab.SabAttributeAggregator;
 import aa.aggregators.sbs.SBSAttributeAggregator;
 import aa.aggregators.test.TestingAttributeAggregator;
@@ -16,6 +15,7 @@ import aa.aggregators.voot.VootAttributeAggregator;
 import aa.cache.UserAttributeCache;
 import aa.config.AuthorityConfiguration;
 import aa.config.AuthorityResolver;
+import aa.model.AggregatorType;
 import aa.model.AttributeAuthorityConfiguration;
 import aa.repository.AccountRepository;
 import aa.repository.PseudoEmailRepository;
@@ -105,6 +105,13 @@ public class AttributeAggregatorConfiguration {
                 if (id.startsWith("test:")) {
                     return new TestingAttributeAggregator(configuration);
                 } else {
+                    // Check if there is a type that can be used
+                    if (null != configuration.getType()) {
+                        if (configuration.getType() == AggregatorType.rest) {
+                            return new RestAttributeAggregator(configuration);
+                        }
+                    }
+
                     //We don't want to fail here as it might be that new AA's are already defined but not yet implemented
                     return null;
                 }

--- a/aa-server/src/main/java/aa/aggregators/rest/RestAttributeAggregator.java
+++ b/aa-server/src/main/java/aa/aggregators/rest/RestAttributeAggregator.java
@@ -1,0 +1,111 @@
+package aa.aggregators.rest;
+
+import aa.aggregators.AbstractAttributeAggregator;
+import aa.model.ArpValue;
+import aa.model.AttributeAuthorityConfiguration;
+import aa.model.PathParam;
+import aa.model.UserAttribute;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class RestAttributeAggregator extends AbstractAttributeAggregator {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAttributeAggregator(AttributeAuthorityConfiguration attributeAuthorityConfiguration) {
+        super(attributeAuthorityConfiguration);
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public List<UserAttribute> aggregate(List<UserAttribute> input, Map<String, List<ArpValue>> arpAttributes) {
+        AttributeAuthorityConfiguration configuration = getAttributeAuthorityConfiguration();
+        String data = fetchData(input, configuration);
+        return mapToAttributes(data, configuration);
+    }
+
+    private String fetchData(List<UserAttribute> attributes, AttributeAuthorityConfiguration configuration) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (null != configuration.getHeaders()) {
+            configuration.getHeaders().forEach(header -> headers.add(header.getKey(), header.getValue()));
+        }
+        // Process path parameters
+        String endpoint = configuration.getEndpoint();
+        if (null != configuration.getPathParams()) {
+            configuration.getPathParams().sort(Comparator.comparing(PathParam::getIndex));
+            Object[] pathParamValues = configuration.getPathParams().stream()
+                    .map(pathParam -> attributes.stream()
+                            .filter(attribute -> attribute.getName().equals(pathParam.getSourceAttribute()))
+                            .map(attribute -> attribute.getValues().get(0))
+                            .collect(Collectors.toList())
+                    )
+                    .flatMap(List::stream).toArray();
+            endpoint = String.format(endpoint, pathParamValues);
+        }
+        // Process request parameters
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(endpoint);
+        if (null != configuration.getRequestParams()) {
+            configuration.getRequestParams().forEach(requestParam -> attributes.stream()
+                    .filter(attribute -> attribute.getName().equals(requestParam.getSourceAttribute())).findFirst()
+                    .ifPresent(param -> builder.queryParam(requestParam.getName(), param.getValues().get(0)))
+            );
+        }
+
+        HttpMethod method = HttpMethod.resolve(configuration.getRequestMethod());
+        if (null == method) {
+            LOG.info("Can not resolve unknown HTTP method: {}, defaulting to GET", configuration.getRequestMethod());
+            method = HttpMethod.GET;
+        }
+        return getRestTemplate().exchange(builder.toUriString(), method,
+                new HttpEntity<>(null, headers), new ParameterizedTypeReference<String>() {
+                }).getBody();
+    }
+
+    private List<UserAttribute> mapToAttributes(String data, AttributeAuthorityConfiguration configuration) {
+        List<UserAttribute> result = new ArrayList<>();
+
+        if (null == configuration.getMappings() || configuration.getMappings().isEmpty()) {
+            LOG.warn("No configured mappings found for retrieved data from REST endpoint, returning empty enriched attribute list");
+            return result;
+        }
+
+        JsonNode node;
+        try {
+            node = objectMapper.readTree(data);
+        } catch (JsonProcessingException exception) {
+            LOG.warn("Can not parse response from REST endpoint, returning empty enriched attribute list");
+            exception.printStackTrace();
+            return result;
+        }
+
+        configuration.getMappings().forEach(mapping -> {
+            JsonNode jsonNode = node.findValue(mapping.getResponseKey());
+            if (null != jsonNode) {
+                result.add(createAttribute(configuration.getId(), mapping.getTargetAttribute(), jsonNode.asText()));
+            }
+        });
+
+        return result;
+    }
+
+    private UserAttribute createAttribute(String sourceId, String key, String value) {
+        UserAttribute attribute = new UserAttribute();
+        attribute.setName(key);
+        attribute.setValues(List.of(value));
+        attribute.setSource(sourceId);
+        return attribute;
+    }
+
+}

--- a/aa-server/src/main/java/aa/model/AggregatorType.java
+++ b/aa-server/src/main/java/aa/model/AggregatorType.java
@@ -1,0 +1,7 @@
+package aa.model;
+
+public enum AggregatorType {
+
+    rest
+
+}

--- a/aa-server/src/main/java/aa/model/AttributeAuthorityConfiguration.java
+++ b/aa-server/src/main/java/aa/model/AttributeAuthorityConfiguration.java
@@ -18,9 +18,15 @@ public class AttributeAuthorityConfiguration {
 
     private String id;
     private String description;
+    private AggregatorType type;
     private String endpoint;
     private String user;
+    private String requestMethod;
+    private List<Header> headers;
+    private List<PathParam> pathParams;
+    private List<RequestParam> requestParams;
     private List<Attribute> attributes;
+    private List<Mapping> mappings;
     private List<RequiredInputAttribute> requiredInputAttributes = new ArrayList<>();
     private int timeOut;
     private String validationRegExp;

--- a/aa-server/src/main/java/aa/model/Header.java
+++ b/aa-server/src/main/java/aa/model/Header.java
@@ -1,0 +1,18 @@
+package aa.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Header {
+
+    private String key;
+
+    private String value;
+
+}

--- a/aa-server/src/main/java/aa/model/Mapping.java
+++ b/aa-server/src/main/java/aa/model/Mapping.java
@@ -1,0 +1,18 @@
+package aa.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Mapping {
+
+    private String responseKey;
+
+    private String targetAttribute;
+
+}

--- a/aa-server/src/main/java/aa/model/PathParam.java
+++ b/aa-server/src/main/java/aa/model/PathParam.java
@@ -1,0 +1,18 @@
+package aa.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PathParam {
+
+    private int index;
+
+    private String sourceAttribute;
+
+}

--- a/aa-server/src/main/java/aa/model/RequestParam.java
+++ b/aa-server/src/main/java/aa/model/RequestParam.java
@@ -1,0 +1,18 @@
+package aa.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestParam {
+
+    private String name;
+
+    private String sourceAttribute;
+
+}

--- a/aa-server/src/test/java/aa/aggregators/rest/RestAttributeAggregatorTest.java
+++ b/aa-server/src/test/java/aa/aggregators/rest/RestAttributeAggregatorTest.java
@@ -1,0 +1,229 @@
+package aa.aggregators.rest;
+
+import aa.model.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.*;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+public class RestAttributeAggregatorTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private RestAttributeAggregator subject;
+
+    private AttributeAuthorityConfiguration configuration;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @BeforeEach
+    void setUp() {
+        configuration = new AttributeAuthorityConfiguration("domain1");
+        configuration.setEndpoint("https://domain1.com");
+        configuration.setTimeOut(15000);
+        configuration.setRequestMethod("GET");
+        subject = new RestAttributeAggregator(configuration);
+        ReflectionTestUtils.setField(subject, "restTemplate", restTemplate);
+    }
+
+    @Test
+    void aggregateRequestWithHeaders() {
+        configuration.setHeaders(List.of(
+                new Header("headerKey1", "headerValue1"),
+                new Header("headerKey2", "headerValue2")
+        ));
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenReturn(ResponseEntity.ok("response"));
+
+        HttpHeaders expectedHeaders = new HttpHeaders();
+        expectedHeaders.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        expectedHeaders.setContentType(MediaType.APPLICATION_JSON);
+        expectedHeaders.add("headerKey1", "headerValue1");
+        expectedHeaders.add("headerKey2", "headerValue2");
+
+        subject.aggregate(Collections.emptyList(), Collections.emptyMap());
+
+        verify(restTemplate, times(1)).exchange(
+                eq("https://domain1.com"),
+                eq(HttpMethod.GET),
+                eq(new HttpEntity<>(null, expectedHeaders)),
+                any(ParameterizedTypeReference.class)
+        );
+    }
+
+    @Test
+    void aggregateRequestWithPathParams() {
+        configuration.setPathParams(new ArrayList<>(List.of(
+                new PathParam(0, "attribute1"),
+                new PathParam(1, "attribute2")
+        )));
+        configuration.setEndpoint("https://domain1.com/%s/sub/%s");
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenReturn(ResponseEntity.ok("response"));
+
+        subject.aggregate(input, Collections.emptyMap());
+
+        verify(restTemplate, times(1)).exchange(
+                eq("https://domain1.com/value1/sub/value2"),
+                eq(HttpMethod.GET),
+                any(),
+                any(ParameterizedTypeReference.class)
+        );
+    }
+
+    @Test
+    void aggregateRequestWithRequestParams() {
+        configuration.setRequestParams(new ArrayList<>(List.of(
+                new RequestParam("param1", "attribute1"),
+                new RequestParam("param2", "attribute2")
+        )));
+        configuration.setEndpoint("https://domain1.com");
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenReturn(ResponseEntity.ok("response"));
+
+        subject.aggregate(input, Collections.emptyMap());
+
+        verify(restTemplate, times(1)).exchange(
+                eq("https://domain1.com?param1=value1&param2=value2"),
+                eq(HttpMethod.GET),
+                any(),
+                any(ParameterizedTypeReference.class)
+        );
+    }
+
+    @Test
+    void aggregateRequestDefaultToGet() {
+        configuration.setRequestMethod(null);
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenReturn(ResponseEntity.ok("response"));
+
+        subject.aggregate(Collections.emptyList(), Collections.emptyMap());
+
+        verify(restTemplate, times(1)).exchange(
+                eq("https://domain1.com"),
+                eq(HttpMethod.GET),
+                any(),
+                any(ParameterizedTypeReference.class)
+        );
+    }
+
+    @Test
+    void aggregate() throws IOException {
+        configuration.setRequestParams(new ArrayList<>(List.of(
+                new RequestParam("param1", "attribute1"),
+                new RequestParam("param2", "attribute2")
+        )));
+        configuration.setMappings(List.of(
+                new Mapping("field1", "target1"),
+                new Mapping("field2", "target2")
+        ));
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        JsonNode apiResponse = objectMapper
+                .readValue(new ClassPathResource("rest/result.json").getInputStream(), JsonNode.class);
+        String stringResponse = objectMapper.writeValueAsString(apiResponse);
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenReturn(ResponseEntity.ok(stringResponse));
+
+        List<UserAttribute> result = subject.aggregate(input, Collections.emptyMap());
+
+        verify(restTemplate, times(1)).exchange(
+                eq("https://domain1.com?param1=value1&param2=value2"),
+                eq(HttpMethod.GET),
+                any(),
+                any(ParameterizedTypeReference.class)
+        );
+        assertEquals(2, result.size());
+        assertEquals("target1", result.get(0).getName());
+        assertEquals("value1", result.get(0).getValues().get(0));
+        assertEquals("target2", result.get(1).getName());
+        assertEquals("value2", result.get(1).getValues().get(0));
+    }
+
+    @Test
+    void aggregateRequestNoMappings() throws IOException {
+        configuration.setRequestParams(new ArrayList<>(List.of(
+                new RequestParam("param1", "attribute1"),
+                new RequestParam("param2", "attribute2")
+        )));
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        JsonNode apiResponse = objectMapper
+                .readValue(new ClassPathResource("rest/result.json").getInputStream(), JsonNode.class);
+        String stringResponse = objectMapper.writeValueAsString(apiResponse);
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenReturn(ResponseEntity.ok(stringResponse));
+
+        List<UserAttribute> result = subject.aggregate(input, Collections.emptyMap());
+
+        verify(restTemplate, times(1)).exchange(
+                eq("https://domain1.com?param1=value1&param2=value2"),
+                eq(HttpMethod.GET),
+                any(),
+                any(ParameterizedTypeReference.class)
+        );
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void aggregateRequestInvalidApiResponse() {
+        configuration.setRequestParams(new ArrayList<>(List.of(
+                new RequestParam("param1", "attribute1"),
+                new RequestParam("param2", "attribute2")
+        )));
+        configuration.setMappings(List.of(
+                new Mapping("field1", "target1"),
+                new Mapping("field2", "target2")
+        ));
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenReturn(ResponseEntity.ok("invalid"));
+
+        List<UserAttribute> result = subject.aggregate(input, Collections.emptyMap());
+
+        verify(restTemplate, times(1)).exchange(
+                eq("https://domain1.com?param1=value1&param2=value2"),
+                eq(HttpMethod.GET),
+                any(),
+                any(ParameterizedTypeReference.class)
+        );
+        assertTrue(result.isEmpty());
+    }
+
+}

--- a/aa-server/src/test/resources/rest/result.json
+++ b/aa-server/src/test/resources/rest/result.json
@@ -1,0 +1,9 @@
+{
+  "records": [
+    {
+      "field1": "value1",
+      "field2": "value2"
+    }
+  ],
+  "count": 1
+}


### PR DESCRIPTION
Hi all,

We've implemented a reusable REST aggregator which can be used to retrieve data from REST endpoints. A new aggregator is added purely via configuration.

Below is the documentation to go with this implementation:

## REST Attribute Aggregator

This reusable aggregator can be used for retrieving data from a REST endpoint and supports various options for configuring a HTTP request to that endpoint e.g. an API key. 

New entries are added in attributeAuthorities.yml.

Below is an example of the full configuration with explanations for the options:

    - {
      id: "<id>",
      description: "<description>",
      endpoint: "<endpoint>",
      type: "rest",
      // Username for basic authentication
      user: "", 
      // Password for basic authentication
      password: "", 
      // Headers to add in the HTTP request 
      headers: [ 
          {
            "key": "<key>",
            "value": "<value>",
          }
      ],
      // Path parameters to use in the value for 'endpoint' 
      // Wildcards can be added with %s e.g. https://endpoint/%s/subpath/%s...
      // The index below will correspond to the order in which the wildcards are replaced
      // sourceAttribute refers to the attribute received from EngineBlock to use as the substitute
      pathParams: [
          {
            "index": 0,
            "sourceAttribute": "urn:mace:terena.org:attribute-def:schacHomeOrganization"
          },
          {
            "index": 1,
            "sourceAttribute": "urn:mace:dir:attribute-def:uid"
          }
      ],
      // Options are 'GET', 'POST', 'PUT', 'DELETE', default is 'GET'
      requestMethod: 'GET',
      // Request parameters to use in the HTTP request, will be appended as ?name=value&...
      // sourceAttribute refers to the attribute received from EngineBlock to use as the substitute
      requestParams: [
          {
            "name": "<name>",
            "sourceAttribute": "urn:mace:terena.org:attribute-def:schacHomeOrganization"
          }
      ],
      // Mapping to apply to the response received from the HTTP request
      // responseKey corresponds to the field in the response object of which to retrieve the value
      // targetAttribute corresponds to the attribute to send the value as in the result of aggregation
      mappings: [
          {
            "responseKey": "myResponseKey",
            "targetAttribute": "myTargetAttribute"
          }
      ],
      timeOut: 15000,
      attributes: [],
      requiredInputAttributes: [
          {
            name: "urn:mace:terena.org:attribute-def:schacHomeOrganization",
          }
      ],
      validationRegExp: "[a-zA-Z0-9]*"
    }
