### PR TITLE
Add filter support for mapping in REST Attribute Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,10 @@ Below is an example of the full configuration with explanations for the options:
                 "name": "<name>",
                 "sourceAttribute": "urn:mace:terena.org:attribute-def:schacHomeOrganization"
             }
-        ],
+        ],x
+        // Optional: specify node from API response for which to apply mapping for, by default the root node is used.
+        // Nesting is possible using dot notation e.g field.nestedField1[0].nestedField2 etc.
+        rootListName: "<node name>",
         // Mapping to apply to the response received from the HTTP request
         // responseKey corresponds to the field in the response object of which to retrieve the value
         // targetAttribute corresponds to the attribute to send the value as in the result of aggregation
@@ -166,6 +169,13 @@ Below is an example of the full configuration with explanations for the options:
         {
             "responseKey": "myResponseKey",
             "targetAttribute": "myTargetAttribute"
+            // Optional: filter to search for specific node relative to the node used as root 
+            // (after applying rootListName if present). Useful in case of searching for value 
+            // where other field equals another value. 
+            "filter": {
+                "key": "<key>",
+                "value": "<value>"
+            }
         }
         ],
         timeOut: 15000,

--- a/aa-server/pom.xml
+++ b/aa-server/pom.xml
@@ -113,6 +113,11 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.13.1</version>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>json-path</artifactId>
+            <version>4.5.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -128,12 +133,6 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>4.5.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>json-path</artifactId>
             <version>4.5.0</version>
             <scope>test</scope>
         </dependency>

--- a/aa-server/src/main/java/aa/aggregators/rest/RestAttributeAggregator.java
+++ b/aa-server/src/main/java/aa/aggregators/rest/RestAttributeAggregator.java
@@ -101,10 +101,8 @@ public class RestAttributeAggregator extends AbstractAttributeAggregator {
         rootList.forEach(m -> configuration.getMappings().forEach(mapping -> {
             // Check if filter is present and applies
             MappingFilter filter = mapping.getFilter();
-            if (null != filter) {
-                if (!filter.getValue().equals(m.get(filter.getKey()))) {
-                    return;
-                }
+            if (null != filter && StringUtils.hasText(filter.getKey()) && !filter.getValue().equals(m.get(filter.getKey()))) {
+                return;
             }
             Object o = m.get(mapping.getResponseKey());
             if (o != null) {

--- a/aa-server/src/main/java/aa/model/MappingFilter.java
+++ b/aa-server/src/main/java/aa/model/MappingFilter.java
@@ -9,12 +9,10 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Mapping {
+public class MappingFilter {
 
-    private String responseKey;
+    private String key;
 
-    private String targetAttribute;
-
-    private MappingFilter filter;
+    private String value;
 
 }

--- a/aa-server/src/test/java/aa/aggregators/rest/AccessAttributeAggregatorTest.java
+++ b/aa-server/src/test/java/aa/aggregators/rest/AccessAttributeAggregatorTest.java
@@ -45,7 +45,7 @@ public class AccessAttributeAggregatorTest {
         configuration.setRequiredInputAttributes(List.of(new RequiredInputAttribute(NAME_ID), new RequiredInputAttribute(SP_ENTITY_ID)));
         configuration.setPathParams(Arrays.asList(new PathParam(1, NAME_ID)));
         configuration.setRequestParams(List.of(new RequestParam("SPentityID","SPentityID")));
-        configuration.setMappings(List.of(new Mapping("id", IS_MEMBER_OF)));
+        configuration.setMappings(List.of(new Mapping("id", IS_MEMBER_OF, null)));
         subject = new RestAttributeAggregator(configuration);
     }
 

--- a/aa-server/src/test/resources/rest/nested_result.json
+++ b/aa-server/src/test/resources/rest/nested_result.json
@@ -1,0 +1,12 @@
+{
+  "records": [
+    {
+      "field1": "value1",
+      "field2": {
+        "subField1": "subValue1",
+        "subField2": "subValue2"
+      }
+    }
+  ],
+  "count": 1
+}


### PR DESCRIPTION
Made some changes to the REST Attribute Aggregator:
- Updated the usage of rootListName to support nesting using dot notation e.g. field.subField[index]
- Added support for filters for mapping attributes

The latter can be used to support a response such as 
```
{
  "results": [
    {
      "prop1": "<val1>",
      "prop2": [
        {
          "subProp1": "<subVal1a>",
          "subProp2": false
        },
        {
          "subProp1": "<subVal1b>",
          "subProp2": false
        },
        {
          "subProp1": "<subVal1c>",
          "subProp2": true
        }
      ]
    }
  ],
  "count": 1
}
```
In this case it is now possible to map 'subProp2' where subProp1='subVal1c' to a specific attribute.
