### PR TITLE
Add caching support for REST Attribute Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ Below is an example of the full configuration with explanations for the options:
             }
         ],x
         // Optional: specify node from API response for which to apply mapping for, by default the root node is used.
-        // Nesting is possible using dot notation e.g field.nestedField1[0].nestedField2 etc.
+        // Nesting is possible using dot notation e.g field.nestedField1[0].nestedField2 etc. Any paths navigations
+        // are possible from GPath
         rootListName: "<node name>",
         // Mapping to apply to the response received from the HTTP request
         // responseKey corresponds to the field in the response object of which to retrieve the value
@@ -185,7 +186,32 @@ Below is an example of the full configuration with explanations for the options:
                 name: "urn:mace:terena.org:attribute-def:schacHomeOrganization",
             }
         ],
-        validationRegExp: "[a-zA-Z0-9]*"
+        validationRegExp: "[a-zA-Z0-9]*",
+        // Optional: specify caching which will be used in case an error occurs when retrieving data.
+        // Cache endpoint is configured separately but should return the same response structure as the primary endpoint.
+        cache: {
+            enabled: true,
+            endpoint: "<endpoint>",
+            headers: [
+                {
+                  "key": "<key>",
+                  "value": "<value>",
+                }
+            ],
+            // Specify path to relevant record. Caution: if an entire list is retrieved then it is advised to 
+            // define a filter to the relevant record e.g. findAll{record->record.%s == \"%s\"}[0]. In this example
+            // attributes are used from the 'filters' section so that it is possible to filter by properties. Filters
+            // are optional. Path navigations and filter are possible from GPath
+            rootListName: "<node name>", 
+            filters: {
+                index: 0,
+                key: "<key>",
+                sourceAttribute: "<attribute name>"
+            },
+            requestMethod: 'GET',
+            // Specify frequency at which data is retrieved from the cache endpoint
+            refreshCron: "* * * * * *"
+        }
     }
 
 ### [Configuration and deployment](#configuration-and-deployment)

--- a/aa-server/src/main/java/aa/aggregators/AbstractAttributeAggregator.java
+++ b/aa-server/src/main/java/aa/aggregators/AbstractAttributeAggregator.java
@@ -1,6 +1,7 @@
 package aa.aggregators;
 
 import aa.model.AttributeAuthorityConfiguration;
+import aa.model.Cache;
 import aa.model.RequiredInputAttribute;
 import aa.model.UserAttribute;
 import org.apache.http.auth.AuthScope;
@@ -178,5 +179,10 @@ public abstract class AbstractAttributeAggregator implements AttributeAggregator
                     pattern);
         }
         return result;
+    }
+
+    public boolean cachingEnabled() {
+        Cache cacheConfig = attributeAuthorityConfiguration.getCache();
+        return null != cacheConfig && Boolean.TRUE.equals(cacheConfig.getEnabled());
     }
 }

--- a/aa-server/src/main/java/aa/aggregators/AttributeAggregator.java
+++ b/aa-server/src/main/java/aa/aggregators/AttributeAggregator.java
@@ -35,4 +35,6 @@ public interface AttributeAggregator {
 
     List<UserAttribute> filterInvalidResponses(List<UserAttribute> input);
 
+    boolean cachingEnabled();
+
 }

--- a/aa-server/src/main/java/aa/aggregators/rest/RestAttributeAggregator.java
+++ b/aa-server/src/main/java/aa/aggregators/rest/RestAttributeAggregator.java
@@ -6,20 +6,25 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.path.json.JsonPath;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
+import org.springframework.http.*;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class RestAttributeAggregator extends AbstractAttributeAggregator {
+public class RestAttributeAggregator extends AbstractAttributeAggregator implements Runnable {
+
+    private static final String emptyResponse = "[]";
 
     private final ObjectMapper objectMapper;
+
+    boolean cacheUsed = false;
+
+    private String cacheData;
 
     public RestAttributeAggregator(AttributeAuthorityConfiguration attributeAuthorityConfiguration) {
         super(attributeAuthorityConfiguration);
@@ -28,26 +33,54 @@ public class RestAttributeAggregator extends AbstractAttributeAggregator {
 
     @Override
     public List<UserAttribute> aggregate(List<UserAttribute> input, Map<String, List<ArpValue>> arpAttributes) {
+        cacheUsed = false;
         AttributeAuthorityConfiguration configuration = getAttributeAuthorityConfiguration();
         String data = fetchData(input, configuration);
-        return mapToAttributes(data, configuration);
+        return mapToAttributes(data, configuration, input);
+    }
+
+    @Override
+    public void run() {
+        if (cachingEnabled()) {
+            AttributeAuthorityConfiguration configuration = getAttributeAuthorityConfiguration();
+            LOG.debug("Refreshing cache for REST aggregator {}", configuration.getId());
+            refreshCache(configuration);
+        }
     }
 
     private String fetchData(List<UserAttribute> attributes, AttributeAuthorityConfiguration configuration) {
+        try {
+            return doRequest(configuration.getHeaders(), configuration.getUser(), configuration.getPassword(),
+                    configuration.getEndpoint(), configuration.getPathParams(), attributes,
+                    configuration.getRequestParams(), configuration.getRequestMethod()).getBody();
+        } catch (HttpStatusCodeException exception) {
+            LOG.warn("Exception occurred during data retrieval for REST aggregator {}:", configuration.getId(), exception);
+            if (!exception.getResponseBodyAsString().isEmpty()) {
+                LOG.warn("Response body found for exception, returning response body");
+                return exception.getResponseBodyAsString();
+            }
+            return handleException(exception, configuration);
+        } catch (RestClientException exception) {
+            LOG.warn("Exception occurred during data retrieval for REST aggregator {}:", configuration.getId(), exception);
+            return handleException(exception, configuration);
+        }
+    }
+
+    private ResponseEntity<String> doRequest(List<Header> configHeaders, String user, String password, String endpoint, List<PathParam> pathParams,
+                                             List<UserAttribute> attributes, List<RequestParam> requestParams, String requestMethod) {
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
-        if (null != configuration.getHeaders()) {
-            configuration.getHeaders().forEach(header -> headers.add(header.getKey(), header.getValue()));
+        if (null != configHeaders) {
+            configHeaders.forEach(header -> headers.add(header.getKey(), header.getValue()));
         }
-        if (configuration.getUser() != null && configuration.getPassword() != null) {
-            headers.setBasicAuth(configuration.getUser(), configuration.getPassword());
+        if (user != null && password != null) {
+            headers.setBasicAuth(user, password);
         }
         // Process path parameters
-        String endpoint = configuration.getEndpoint();
-        if (null != configuration.getPathParams()) {
-            configuration.getPathParams().sort(Comparator.comparing(PathParam::getIndex));
-            Object[] pathParamValues = configuration.getPathParams().stream()
+        if (null != pathParams) {
+            pathParams.sort(Comparator.comparing(PathParam::getIndex));
+            Object[] pathParamValues = pathParams.stream()
                     .map(pathParam -> attributes.stream()
                             .filter(attribute -> attribute.getName().equals(pathParam.getSourceAttribute()))
                             .map(attribute -> attribute.getValues().get(0))
@@ -58,57 +91,48 @@ public class RestAttributeAggregator extends AbstractAttributeAggregator {
         }
         // Process request parameters
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(endpoint);
-        if (null != configuration.getRequestParams()) {
-            configuration.getRequestParams().forEach(requestParam -> attributes.stream()
+        if (null != requestParams) {
+            requestParams.forEach(requestParam -> attributes.stream()
                     .filter(attribute -> attribute.getName().equals(requestParam.getSourceAttribute())).findFirst()
                     .ifPresent(param -> builder.queryParam(requestParam.getName(), param.getValues().get(0)))
             );
         }
 
-        HttpMethod method = HttpMethod.resolve(configuration.getRequestMethod());
+        HttpMethod method = HttpMethod.resolve(requestMethod);
         if (null == method) {
-            LOG.info("Can not resolve unknown HTTP method: {}, defaulting to GET", configuration.getRequestMethod());
+            LOG.info("Can not resolve unknown HTTP method: {}, defaulting to GET", requestMethod);
             method = HttpMethod.GET;
         }
+
         return getRestTemplate().exchange(builder.toUriString(), method,
-                new HttpEntity<>(null, headers), new ParameterizedTypeReference<String>() {
-                }).getBody();
+                new HttpEntity<>(null, headers), new ParameterizedTypeReference<>() {});
     }
 
-    @SuppressWarnings("unchecked")
-    private List<UserAttribute> mapToAttributes(String data, AttributeAuthorityConfiguration configuration) {
+    private List<UserAttribute> mapToAttributes(String data, AttributeAuthorityConfiguration configuration, List<UserAttribute> input) {
         if (CollectionUtils.isEmpty(configuration.getMappings())) {
             throw new IllegalArgumentException("No configured mappings found for retrieved data from REST endpoint, returning empty enriched attribute list");
         }
 
         List<UserAttribute> result = new ArrayList<>();
-        List<Map<String, Object>> rootList;
-        try {
-            Object obj = objectMapper.readValue(data, Object.class);
-            if (StringUtils.hasText(configuration.getRootListName())) {
-                obj = JsonPath.from(data).get(configuration.getRootListName());
-            }
+        List<Map<String, Object>> rootList = searchRootElement(data, configuration, input);
 
-            if (obj instanceof List) {
-                rootList = (List<Map<String, Object>>) obj;
-            } else {
-                rootList = List.of((Map<String, Object>) obj);
-            }
-        } catch (JsonProcessingException exception) {
-            LOG.error("Can not parse response from REST endpoint, returning empty enriched attribute list", exception);
-            return Collections.emptyList();
+        if (rootList.isEmpty() && Boolean.TRUE.equals(configuration.getHandleResponseErrorAsEmpty())) {
+            configuration.getMappings().forEach(mapping ->
+                    result.add(createAttribute(configuration.getId(), mapping.getTargetAttribute(), ""))
+            );
+        } else {
+            rootList.forEach(m -> configuration.getMappings().forEach(mapping -> {
+                // Check if filter is present and applies
+                MappingFilter filter = mapping.getFilter();
+                if (null != filter && StringUtils.hasText(filter.getKey()) && !filter.getValue().equals(m.get(filter.getKey()))) {
+                    return;
+                }
+                Object o = m.get(mapping.getResponseKey());
+                if (o != null) {
+                    result.add(createAttribute(configuration.getId(), mapping.getTargetAttribute(), o.toString()));
+                }
+            }));
         }
-        rootList.forEach(m -> configuration.getMappings().forEach(mapping -> {
-            // Check if filter is present and applies
-            MappingFilter filter = mapping.getFilter();
-            if (null != filter && StringUtils.hasText(filter.getKey()) && !filter.getValue().equals(m.get(filter.getKey()))) {
-                return;
-            }
-            Object o = m.get(mapping.getResponseKey());
-            if (o != null) {
-                result.add(createAttribute(configuration.getId(), mapping.getTargetAttribute(), o.toString()));
-            }
-        }));
         // Make sure that all values with the same name are grouped together
         Map<String, List<UserAttribute>> groupedBy = result.stream().collect(Collectors.groupingBy(UserAttribute::getName));
         return groupedBy.entrySet().stream().map(entry ->
@@ -122,12 +146,90 @@ public class RestAttributeAggregator extends AbstractAttributeAggregator {
         ).collect(Collectors.toList());
     }
 
+    /**
+     * Search for relevant root element from the provided data. Data is handled as JSON string to which JSONPath mapping
+     * is applied. In case cache data is used then apply mapping and filtering defined in cache configuration.
+     *
+     * @param data Data retrieved from REST API
+     * @param configuration Relevant attribute authority configuration
+     * @param input Input attributes to apply filtering to cache data if required
+     * @return List of relevant records from data
+     */
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> searchRootElement(String data, AttributeAuthorityConfiguration configuration, List<UserAttribute> input) {
+        List<Map<String, Object>> rootList;
+        try {
+            Object obj = objectMapper.readValue(data, Object.class);
+
+            // Cache can contain irrelevant records, apply filter to search for relevant records
+            if (cacheUsed) {
+                String cacheRootList = configuration.getCache().getRootListName();
+                List<CacheFilter> cacheFilters = configuration.getCache().getFilters();
+                if (null != cacheFilters && !cacheFilters.isEmpty()) {
+                    cacheFilters.sort(Comparator.comparing(CacheFilter::getIndex));
+                    for (CacheFilter cacheFilter : cacheFilters) {
+                        String filterKey = cacheFilter.getKey();
+                        UserAttribute filterAttribute = input.stream().filter(attribute ->
+                                attribute.getName().equals(cacheFilter.getSourceAttribute())).findFirst().orElse(null);
+                        String filterValue = null != filterAttribute ? filterAttribute.getValues().get(0) : null;
+
+                        if (null != filterValue) {
+                            cacheRootList = String.format(cacheRootList, filterKey, filterValue);
+                        }
+                    }
+                }
+
+                obj = JsonPath.from(data).get(cacheRootList);
+            } else {
+                // Cache data not used, apply normal root element mapping
+                if (StringUtils.hasText(configuration.getRootListName())) {
+                    obj = JsonPath.from(data).get(configuration.getRootListName());
+                }
+            }
+
+            if (obj instanceof List) {
+                rootList = (List<Map<String, Object>>) obj;
+            } else {
+                rootList = List.of((Map<String, Object>) obj);
+            }
+        } catch (JsonProcessingException | IllegalArgumentException | NullPointerException exception) {
+            LOG.warn("Can not parse response from REST endpoint of {}, treating as empty response", configuration.getId(), exception);
+            return Collections.emptyList();
+        }
+
+        return rootList;
+    }
+
     private UserAttribute createAttribute(String sourceId, String key, String value) {
         UserAttribute attribute = new UserAttribute();
         attribute.setName(key);
         attribute.setValues(List.of(value));
         attribute.setSource(sourceId);
         return attribute;
+    }
+
+    private void refreshCache(AttributeAuthorityConfiguration configuration) {
+        try {
+            Cache cache = configuration.getCache();
+            this.cacheData = doRequest(cache.getHeaders(), configuration.getUser(), configuration.getPassword(),
+                    cache.getEndpoint(), null, null, null, cache.getRequestMethod())
+                    .getBody();
+        } catch (RestClientException exception) {
+            LOG.warn("Failed to retrieve cache data", exception);
+        }
+    }
+
+    private String handleException(RestClientException exception, AttributeAuthorityConfiguration configuration) {
+        if (cachingEnabled()) {
+            LOG.info("Cache configuration found and enabled, returning cache data");
+            cacheUsed = true;
+            return cacheData;
+        }
+        if (Boolean.TRUE.equals(configuration.getHandleResponseErrorAsEmpty())) {
+            LOG.info("Exception thrown but configured to handle as empty data, returning empty data");
+            return emptyResponse;
+        }
+        throw exception;
     }
 
 }

--- a/aa-server/src/main/java/aa/config/TaskSchedulerConfig.java
+++ b/aa-server/src/main/java/aa/config/TaskSchedulerConfig.java
@@ -1,0 +1,19 @@
+package aa.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class TaskSchedulerConfig {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+        threadPoolTaskScheduler.setPoolSize(5);
+        threadPoolTaskScheduler.setThreadNamePrefix("ThreadPoolTaskScheduler");
+        return threadPoolTaskScheduler;
+    }
+
+}

--- a/aa-server/src/main/java/aa/model/AttributeAuthorityConfiguration.java
+++ b/aa-server/src/main/java/aa/model/AttributeAuthorityConfiguration.java
@@ -29,10 +29,12 @@ public class AttributeAuthorityConfiguration {
     private List<Attribute> attributes;
     private List<Mapping> mappings;
     private List<RequiredInputAttribute> requiredInputAttributes = new ArrayList<>();
+    private Cache cache;
     private int timeOut;
     private String validationRegExp;
     @JsonIgnore
     private String password;
+    private Boolean handleResponseErrorAsEmpty;
 
     public AttributeAuthorityConfiguration(String id) {
         this.id = id;

--- a/aa-server/src/main/java/aa/model/Cache.java
+++ b/aa-server/src/main/java/aa/model/Cache.java
@@ -1,0 +1,30 @@
+package aa.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Cache {
+
+    private Boolean enabled;
+
+    private String endpoint;
+
+    private String refreshCron;
+
+    private String requestMethod;
+
+    private List<Header> headers;
+
+    private String rootListName;
+
+    private List<CacheFilter> filters;
+
+}

--- a/aa-server/src/main/java/aa/model/CacheFilter.java
+++ b/aa-server/src/main/java/aa/model/CacheFilter.java
@@ -1,0 +1,20 @@
+package aa.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CacheFilter {
+
+    private Integer index;
+
+    private String key;
+
+    private String sourceAttribute;
+
+}

--- a/aa-server/src/test/java/aa/aggregators/AttributeAggregatorConfigurationTest.java
+++ b/aa-server/src/test/java/aa/aggregators/AttributeAggregatorConfigurationTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.scheduling.TaskScheduler;
 
 import java.io.IOException;
 import java.util.Map;
@@ -33,7 +34,8 @@ public class AttributeAggregatorConfigurationTest {
             new AuthorityResolver(new DefaultResourceLoader(), configFileLocation),
             new NoopUserAttributeCache(),
             Mockito.mock(AccountRepository.class),
-            Mockito.mock(PseudoEmailRepository.class)
+            Mockito.mock(PseudoEmailRepository.class),
+            Mockito.mock(TaskScheduler.class)
         );
     }
 

--- a/aa-server/src/test/java/aa/aggregators/AttributeAggregatorConfigurationTest.java
+++ b/aa-server/src/test/java/aa/aggregators/AttributeAggregatorConfigurationTest.java
@@ -56,4 +56,11 @@ public class AttributeAggregatorConfigurationTest {
         subject.attributeAggregatorService();
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRestAttributeAggregatorService() throws Exception {
+        this.doBefore("classpath:/testRestAttributeAuthority.yml");
+        subject.attributeAggregatorService();
+    }
+
 }

--- a/aa-server/src/test/java/aa/aggregators/rest/RestAttributeAggregatorTest.java
+++ b/aa-server/src/test/java/aa/aggregators/rest/RestAttributeAggregatorTest.java
@@ -12,9 +12,10 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.*;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.*;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -200,8 +201,6 @@ public class RestAttributeAggregatorTest {
                 new UserAttribute("attribute1", Collections.singletonList("value1")),
                 new UserAttribute("attribute2", Collections.singletonList("value2"))
         );
-        Object o = objectMapper
-                .readValue(new ClassPathResource("rest/multiple_result.json").getInputStream(), Object.class);
         JsonNode apiResponse = objectMapper
                 .readValue(new ClassPathResource("rest/multiple_result.json").getInputStream(), JsonNode.class);
         String stringResponse = objectMapper.writeValueAsString(apiResponse);
@@ -237,8 +236,6 @@ public class RestAttributeAggregatorTest {
                 new UserAttribute("attribute1", Collections.singletonList("value1")),
                 new UserAttribute("attribute2", Collections.singletonList("value2"))
         );
-        Object o = objectMapper
-                .readValue(new ClassPathResource("rest/multiple_result.json").getInputStream(), Object.class);
         JsonNode apiResponse = objectMapper
                 .readValue(new ClassPathResource("rest/multiple_result.json").getInputStream(), JsonNode.class);
         String stringResponse = objectMapper.writeValueAsString(apiResponse);
@@ -276,8 +273,6 @@ public class RestAttributeAggregatorTest {
                 new UserAttribute("attribute1", Collections.singletonList("value1")),
                 new UserAttribute("attribute2", Collections.singletonList("value2"))
         );
-        Object o = objectMapper
-                .readValue(new ClassPathResource("rest/multiple_result.json").getInputStream(), Object.class);
         JsonNode apiResponse = objectMapper
                 .readValue(new ClassPathResource("rest/multiple_result.json").getInputStream(), JsonNode.class);
         String stringResponse = objectMapper.writeValueAsString(apiResponse);
@@ -387,6 +382,302 @@ public class RestAttributeAggregatorTest {
                 any(ParameterizedTypeReference.class)
         );
         assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void aggregateApiErrorWithBody() throws IOException {
+        configuration.setRootListName("records");
+        configuration.setRequestParams(new ArrayList<>(List.of(
+                new RequestParam("param1", "attribute1"),
+                new RequestParam("param2", "attribute2")
+        )));
+        configuration.setMappings(List.of(
+                new Mapping("field1", "target1", null),
+                new Mapping("field2", "target2", null)
+        ));
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        JsonNode apiResponse = objectMapper
+                .readValue(new ClassPathResource("rest/result.json").getInputStream(), JsonNode.class);
+        String stringResponse = objectMapper.writeValueAsString(apiResponse);
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenThrow(new HttpStatusCodeException(HttpStatus.NOT_FOUND, "", stringResponse.getBytes(), StandardCharsets.UTF_8) {
+                    @Override
+                    public HttpStatus getStatusCode() {
+                        return super.getStatusCode();
+                    }
+                });
+
+        List<UserAttribute> result = subject.aggregate(input, Collections.emptyMap());
+
+        verify(restTemplate, times(1)).exchange(
+                eq("https://domain1.com?param1=value1&param2=value2"),
+                eq(HttpMethod.GET),
+                any(),
+                any(ParameterizedTypeReference.class)
+        );
+        assertEquals(2, result.size());
+        String value1 = result.stream().filter(userAttribute -> userAttribute.getName().equals("target1")).findFirst().get().getValues().get(0);
+        assertEquals("value1", value1);
+        String value2 = result.stream().filter(userAttribute -> userAttribute.getName().equals("target2")).findFirst().get().getValues().get(0);
+        assertEquals("value2", value2);
+    }
+
+    @Test
+    void aggregateApiErrorWithEmptyBody() {
+        configuration.setRootListName("records");
+        configuration.setRequestParams(new ArrayList<>(List.of(
+                new RequestParam("param1", "attribute1"),
+                new RequestParam("param2", "attribute2")
+        )));
+        configuration.setMappings(List.of(
+                new Mapping("field1", "target1", null),
+                new Mapping("field2", "target2", null)
+        ));
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenThrow(new HttpStatusCodeException(HttpStatus.NOT_FOUND, "", "".getBytes(), StandardCharsets.UTF_8) {
+                    @Override
+                    public HttpStatus getStatusCode() {
+                        return super.getStatusCode();
+                    }
+                });
+
+        assertThrows(HttpStatusCodeException.class, () -> subject.aggregate(input, Collections.emptyMap()));
+    }
+
+    @Test
+    void aggregateApiErrorWithEmptyBodyAsEmptyAttributes() {
+        configuration.setRootListName("records");
+        configuration.setRequestParams(new ArrayList<>(List.of(
+                new RequestParam("param1", "attribute1"),
+                new RequestParam("param2", "attribute2")
+        )));
+        configuration.setMappings(List.of(
+                new Mapping("field1", "target1", null),
+                new Mapping("field2", "target2", null)
+        ));
+        configuration.setHandleResponseErrorAsEmpty(true);
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenThrow(new HttpStatusCodeException(HttpStatus.NOT_FOUND, "", "".getBytes(), StandardCharsets.UTF_8) {
+                    @Override
+                    public HttpStatus getStatusCode() {
+                        return super.getStatusCode();
+                    }
+                });
+
+        List<UserAttribute> result = subject.aggregate(input, Collections.emptyMap());
+
+        verify(restTemplate, times(1)).exchange(
+                eq("https://domain1.com?param1=value1&param2=value2"),
+                eq(HttpMethod.GET),
+                any(),
+                any(ParameterizedTypeReference.class)
+        );
+        assertEquals(2, result.size());
+        assertEquals(1, result.get(0).getValues().size());
+        assertEquals("", result.get(0).getValues().get(0));
+        assertEquals(1, result.get(1).getValues().size());
+        assertEquals("", result.get(1).getValues().get(0));
+    }
+
+    @Test
+    void aggregateRequestApiErrorAsEmptyAttributes() {
+        configuration.setRequestParams(new ArrayList<>(List.of(
+                new RequestParam("param1", "attribute1"),
+                new RequestParam("param2", "attribute2")
+        )));
+        configuration.setMappings(List.of(
+                new Mapping("field1", "target1", null),
+                new Mapping("field2", "target2", null)
+        ));
+        configuration.setHandleResponseErrorAsEmpty(true);
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenThrow(new RestClientException("error"));
+
+        List<UserAttribute> result = subject.aggregate(input, Collections.emptyMap());
+
+        verify(restTemplate, times(1)).exchange(
+                eq("https://domain1.com?param1=value1&param2=value2"),
+                eq(HttpMethod.GET),
+                any(),
+                any(ParameterizedTypeReference.class)
+        );
+        assertEquals(2, result.size());
+        assertEquals(1, result.get(0).getValues().size());
+        assertEquals("", result.get(0).getValues().get(0));
+        assertEquals(1, result.get(1).getValues().size());
+        assertEquals("", result.get(1).getValues().get(0));
+    }
+
+    @Test
+    void aggregateRequestEmptyApiResponseAsEmptyAttributes() {
+        configuration.setRequestParams(new ArrayList<>(List.of(
+                new RequestParam("param1", "attribute1"),
+                new RequestParam("param2", "attribute2")
+        )));
+        configuration.setMappings(List.of(
+                new Mapping("field1", "target1", null),
+                new Mapping("field2", "target2", null)
+        ));
+        configuration.setHandleResponseErrorAsEmpty(true);
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenReturn(ResponseEntity.ok("[]"));
+
+        List<UserAttribute> result = subject.aggregate(input, Collections.emptyMap());
+
+        verify(restTemplate, times(1)).exchange(
+                eq("https://domain1.com?param1=value1&param2=value2"),
+                eq(HttpMethod.GET),
+                any(),
+                any(ParameterizedTypeReference.class)
+        );
+        assertEquals(2, result.size());
+        assertEquals(1, result.get(0).getValues().size());
+        assertEquals("", result.get(0).getValues().get(0));
+        assertEquals(1, result.get(1).getValues().size());
+        assertEquals("", result.get(1).getValues().get(0));
+    }
+
+    @Test
+    void aggregateUseCache() throws IOException {
+        configuration.setRootListName("records");
+        configuration.setRequestParams(new ArrayList<>(List.of(
+                new RequestParam("param1", "attribute1"),
+                new RequestParam("param2", "attribute2")
+        )));
+        configuration.setMappings(List.of(
+                new Mapping("field1", "target1", null),
+                new Mapping("field2", "target2", null)
+        ));
+        configuration.setCache(new Cache(
+                true,
+                "https://cache.com",
+                "",
+                "GET",
+                null,
+                "records.findAll{record->record.%s == \"%s\"}[0]",
+                Collections.singletonList(new CacheFilter(0, "field1", "attribute1"))
+        ));
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        JsonNode apiResponse = objectMapper
+                .readValue(new ClassPathResource("rest/multiple_result.json").getInputStream(), JsonNode.class);
+        String stringResponse = objectMapper.writeValueAsString(apiResponse);
+        when(restTemplate.exchange(eq("https://domain1.com?param1=value1&param2=value2"), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenThrow(new RestClientException("error"));
+        when(restTemplate.exchange(eq("https://cache.com"), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenReturn(ResponseEntity.ok(stringResponse));
+
+        subject.run();
+        List<UserAttribute> result = subject.aggregate(input, Collections.emptyMap());
+
+        verify(restTemplate, times(1)).exchange(
+                eq("https://domain1.com?param1=value1&param2=value2"),
+                eq(HttpMethod.GET),
+                any(),
+                any(ParameterizedTypeReference.class)
+        );
+        verify(restTemplate, times(1)).exchange(
+                eq("https://cache.com"),
+                eq(HttpMethod.GET),
+                any(),
+                any(ParameterizedTypeReference.class)
+        );
+        assertEquals(2, result.size());
+        List<String> values = result.stream().filter(userAttribute -> userAttribute.getName().equals("target1")).findFirst().get().getValues();
+        assertEquals(1, values.size());
+        assertEquals("value1", values.get(0));
+        List<String> values2 = result.stream().filter(userAttribute -> userAttribute.getName().equals("target2")).findFirst().get().getValues();
+        assertEquals(1, values2.size());
+        assertEquals("value2", values2.get(0));
+    }
+
+    @Test
+    void aggregateEmptyResultOnFetchErrorAndEmptyCache() throws IOException {
+        configuration.setRootListName("records");
+        configuration.setRequestParams(new ArrayList<>(List.of(
+                new RequestParam("param1", "attribute1"),
+                new RequestParam("param2", "attribute2")
+        )));
+        configuration.setMappings(List.of(
+                new Mapping("field1", "target1", null),
+                new Mapping("field2", "target2", null)
+        ));
+        configuration.setCache(new Cache(
+                true,
+                "https://cache.com",
+                "",
+                "GET",
+                null,
+                "records",
+                Collections.singletonList(new CacheFilter(0, "field1", "attribute1"))
+        ));
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        JsonNode apiResponse = objectMapper
+                .readValue(new ClassPathResource("rest/multiple_result.json").getInputStream(), JsonNode.class);
+        String stringResponse = objectMapper.writeValueAsString(apiResponse);
+        when(restTemplate.exchange(eq("https://domain1.com?param1=value1&param2=value2"), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenThrow(new RestClientException("error"));
+        when(restTemplate.exchange(eq("https://cache.com"), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenReturn(ResponseEntity.ok(stringResponse));
+
+        List<UserAttribute> result = subject.aggregate(input, Collections.emptyMap());
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void aggregateDoNotUseDisabledCache() {
+        configuration.setRootListName("records");
+        configuration.setRequestParams(new ArrayList<>(List.of(
+                new RequestParam("param1", "attribute1"),
+                new RequestParam("param2", "attribute2")
+        )));
+        configuration.setMappings(List.of(
+                new Mapping("field1", "target1", null),
+                new Mapping("field2", "target2", null)
+        ));
+        configuration.setCache(new Cache(
+                false,
+                "https://cache.com",
+                "",
+                "GET",
+                null,
+                "records",
+                Collections.singletonList(new CacheFilter(0, "field1", "attribute1"))
+        ));
+        List<UserAttribute> input = List.of(
+                new UserAttribute("attribute1", Collections.singletonList("value1")),
+                new UserAttribute("attribute2", Collections.singletonList("value2"))
+        );
+        when(restTemplate.exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class)))
+                .thenThrow(new RestClientException("error"));
+
+        subject.run();
+        assertThrows(RestClientException.class, () -> subject.aggregate(input, Collections.emptyMap()));
     }
 
 }

--- a/aa-server/src/test/resources/testRestAttributeAuthority.yml
+++ b/aa-server/src/test/resources/testRestAttributeAuthority.yml
@@ -1,0 +1,55 @@
+authorities:
+  - {
+    id: "rest",
+    description: "REST endpoint for retrieving data",
+    endpoint: "https://rest-endpoint.com/",
+    type: "rest",
+    headers: [
+      {
+        "key": "Authorization",
+        "value": "Bearer token",
+      }
+    ],
+    requestMethod: 'GET',
+    pathParams: [
+      {
+        "index": 0,
+        "sourceAttribute": "attribute1"
+      }
+    ],
+    handleResponseErrorAsEmpty: true,
+    mappings: [
+      {
+        "responseKey": "responseKey1",
+        "targetAttribute": "targetAttribute1",
+      }
+    ],
+    timeOut: 15000,
+    attributes: [ ],
+    requiredInputAttributes: [
+      {
+        name: "attribute1",
+      }
+    ],
+    validationRegExp: "[a-zA-Z0-9]*",
+    cache: {
+      enabled: true,
+      endpoint: "https://cache.com",
+      headers: [
+        {
+          "key": "Authorization",
+          "value": "Bearer token2",
+        }
+      ],
+      rootListName: "findAll{record->record.%s == \"%s\"}[0]",
+      filters: [
+        {
+          "index": 0,
+          "key": "responseKey1",
+          "sourceAttribute": "attribute1"
+        }
+      ],
+      requestMethod: 'GET',
+      refreshCron: "0 0 0 30 2 *"
+    }
+  }


### PR DESCRIPTION
Hi all,

We've made the following additions to the REST aggregator:

- It is possible to define a cache endpoint. Cache data is retrieved based on a configurable cron schedule, this data will be used if an exception occurs during the initial retrieval of data. Using the cache is disabled by default to stay backwards compatible.
- It is possible to set whether an empty value should be used if a desired attribute cannot be mapped. By default, no attributes are added if nothing can be mapped to stay backwards compatible.