### PR TITLE
Support for logging in JSON and addition of extra information fields in the info actuator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
+        <ecs-logging-java.version>1.7.0</ecs-logging-java.version>
     </properties>
     <dependencies>
         <dependency>
@@ -149,6 +150,11 @@
             <artifactId>junit-vintage-engine</artifactId>
             <version>5.12.2</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>co.elastic.logging</groupId>
+            <artifactId>logback-ecs-encoder</artifactId>
+            <version>${ecs-logging-java.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,19 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                        <configuration>
+                            <additionalProperties>
+                                <java_version>${java.version}</java_version>
+                                <spring_boot_version>${project.parent.version}</spring_boot_version>
+                            </additionalProperties>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>io.github.git-commit-id</groupId>

--- a/src/main/java/aa/actuator/ReleaseDaysInfoContributor.java
+++ b/src/main/java/aa/actuator/ReleaseDaysInfoContributor.java
@@ -1,0 +1,39 @@
+package aa.actuator;
+
+import aa.config.BuildPropertiesConfig;
+import org.springframework.boot.actuate.info.Info;
+import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+
+@Component
+@Import(BuildPropertiesConfig.class)
+public class ReleaseDaysInfoContributor implements InfoContributor {
+
+    private static final String RELEASE_DAYS_KEY = "days_since_release";
+
+    private final BuildProperties buildProperties;
+
+    public ReleaseDaysInfoContributor(BuildProperties buildProperties) {
+        this.buildProperties = buildProperties;
+    }
+
+    @Override
+    public void contribute(Info.Builder builder) {
+        long currentDays = 0L;
+
+        if (null != buildProperties.getTime()) {
+            LocalDate releaseDate = LocalDate.ofInstant(buildProperties.getTime(), ZoneId.systemDefault());
+            LocalDate currentDate = LocalDate.ofInstant(Instant.now(), ZoneId.systemDefault());
+            currentDays = ChronoUnit.DAYS.between(releaseDate, currentDate);
+        }
+        builder.withDetail(RELEASE_DAYS_KEY, currentDays);
+    }
+
+}

--- a/src/main/java/aa/config/BuildPropertiesConfig.java
+++ b/src/main/java/aa/config/BuildPropertiesConfig.java
@@ -1,0 +1,54 @@
+package aa.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Properties;
+
+@Configuration
+public class BuildPropertiesConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BuildPropertiesConfig.class);
+
+    @Bean
+    public BuildProperties buildProperties() {
+        try {
+            Resource resource = new ClassPathResource("META-INF/build-info.properties");
+            if (!resource.exists()) {
+                LOGGER.warn("META-INF/build-info.properties not found, using default build properties");
+                return new BuildProperties(buildDefaultProperties("test"));
+            }
+
+            Properties properties = PropertiesLoaderUtils.loadProperties(resource);
+            Properties flattenedProperties = new Properties();
+            properties.forEach((key, value) -> {
+                String newKey = key.toString().replaceFirst("^build\\.", "");
+                flattenedProperties.put(newKey, value);
+            });
+
+            return new BuildProperties(flattenedProperties);
+        } catch (IOException e) {
+            LOGGER.error("Error loading build-info.properties", e);
+            return new BuildProperties(buildDefaultProperties("error"));
+        }
+    }
+
+    private Properties buildDefaultProperties(String tag) {
+        Properties defaultProperties = new Properties();
+        defaultProperties.put("time", Instant.now().toString());
+        defaultProperties.put("version", String.format("0.0.0-%s", tag.toUpperCase()));
+        defaultProperties.put("name", String.format("%s-build", tag));
+        defaultProperties.put("group", String.format("%s-group", tag));
+        defaultProperties.put("artifact", String.format("%s-artifact", tag));
+        return defaultProperties;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,3 +77,9 @@ info:
   build:
     artifact: "@project.artifactId@"
     version: "@project.version@"
+
+# Logging settings to enable logging in JSON format (e.g. for usage in Graylog or Elastic Stack)
+# logging:
+#   config: classpath:logback-spring.xml
+#   file:
+#     path: logs/

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/spring.log}"/>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+    <include resource="org/springframework/boot/logging/logback/file-appender.xml" />
+    <include resource="co/elastic/logging/logback/boot/ecs-file-appender.xml" />
+
+    <springProperty scope="context" name="serverName" source="HOSTNAME" />
+
+    <root level="INFO">
+        <appender-ref ref="ECS_JSON_FILE"/>
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+
+</configuration>

--- a/src/test/java/aa/actuator/ReleaseDaysInfoContributorTest.java
+++ b/src/test/java/aa/actuator/ReleaseDaysInfoContributorTest.java
@@ -1,0 +1,55 @@
+package aa.actuator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.info.Info;
+import org.springframework.boot.info.BuildProperties;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReleaseDaysInfoContributorTest {
+
+    @Mock
+    private BuildProperties buildProperties;
+
+    @InjectMocks
+    private ReleaseDaysInfoContributor infoIndicator;
+
+    @Test
+    void testSeveralDays() {
+        when(buildProperties.getTime()).thenReturn(Instant.now().minus(Duration.ofDays(3)));
+        Info.Builder builder = new Info.Builder();
+        infoIndicator.contribute(builder);
+        Info info = builder.build();
+
+        assertEquals(3L, info.get("days_since_release"));
+    }
+
+    @Test
+    void testZeroDays() {
+        when(buildProperties.getTime()).thenReturn(Instant.now());
+        Info.Builder builder = new Info.Builder();
+        infoIndicator.contribute(builder);
+        Info info = builder.build();
+
+        assertEquals(0L, info.get("days_since_release"));
+    }
+
+    @Test
+    void testNoBuildInfo() {
+        Info.Builder builder = new Info.Builder();
+        infoIndicator.contribute(builder);
+        Info info = builder.build();
+
+        assertEquals(0L, info.get("days_since_release"));
+    }
+
+}


### PR DESCRIPTION
This PR adds two additional functionalities which are used in our environment:
- Logging in JSON format
- Additional information fields in the info actuator

**Logging in JSON format**
If enabled, the logback-spring.xml configuration can be used to create logfiles in JSON format next to the default line-format. JSON-formatted log files can easily be fed to Elastic stack and Graylog environments using Filebeat.

**Additional information fields in the info actuator**
Additions have been added to expose the following fields in the info actuator under "build":
- version (application version)
- artifact (name of the artifact)
- java_version (used version of Java by the application)
- name (name of the application)
- time (build time)
- spring_boot_version (version of Spring Boot used by the application)
- group (artifact group name)

Additional field added in the info actuator:
- days_since_release (number of days passed since the release was build; eases possibilities to monitor how old the release is and to determine if a new build should be made)

Monitoring software can be pointed to these fields to have a better grasp on applications currently running and improve the application lifecycle management.